### PR TITLE
Исправление ошибки загрузки чека (зависание приложения) 

### DIFF
--- a/app/src/main/java/com/yoshione/fingen/dao/BaseDAO.java
+++ b/app/src/main/java/com/yoshione/fingen/dao/BaseDAO.java
@@ -260,6 +260,7 @@ public abstract class BaseDAO<T extends IAbstractModel> implements AbstractDAO<T
 
     @Override
     public IAbstractModel getModelByName(String name) {
+        name = name.replaceAll("'","''");
         Cursor cursor = mDatabase.query(mTableName, getAllColumns(),
                 COL_SYNC_DELETED + " = 0 AND " + COL_NAME + " = '" + name + "'", null, null, null, null);
         IAbstractModel model = null;


### PR DESCRIPTION
При загрузке чека имеющего в списке товар с одинарной кавычкой могло происходить зависание приложения (при повторной загрузке чека, или при наличии уже в справочнике товара с кавычкой),

Причина - повторная попытка вставить товар, уже имеющийся в справочнике. Приложение некорректно выполняло запрос проверки существования товара (кавычка неверно обрабатывалась в запросе).

https://github.com/ivang7/fingen/pull/22
